### PR TITLE
Unify version numbers used in cargo and flake files

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "Foo"
-version = "0.0.0"
+version = "0.1.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Foo"
-version = "0.0.0"
+version = "0.1.0"
 edition = "2021"
 license = "MIT"
 


### PR DESCRIPTION
Semver projects start at 0.1.0 usually.